### PR TITLE
Rename the main library type

### DIFF
--- a/Sources/XcresultIssues/XcresultIssues.swift
+++ b/Sources/XcresultIssues/XcresultIssues.swift
@@ -1,9 +1,9 @@
 // Copyright 2022 Itty Bitty Apps Pty Ltd. See LICENSE file.
+
 import ArgumentParser
 import Foundation
-// Copyright 2022 Itty Bitty Apps Pty Ltd. See LICENSE file.
 
-public struct XcodeIssues: ParsableCommand {
+public struct XcresultIssues: ParsableCommand {
     public static var configuration = CommandConfiguration(
         commandName: "xcresult-issues",
         abstract: "A utility for reporting issues found in xcresult bundles."

--- a/Sources/xcresult-issues/MainApp.swift
+++ b/Sources/xcresult-issues/MainApp.swift
@@ -7,6 +7,6 @@ import XcresultIssues
 @main
 struct MainApp {
     static func main() {
-        XcodeIssues.main()
+        XcresultIssues.main()
     }
 }


### PR DESCRIPTION
This PR renames the main library type to be consistent with the framework name.